### PR TITLE
README.md: Add a travis build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # A Tor Implementation in Haskell
 
+[![Build Status](https://secure.travis-ci.org/GaloisInc/haskell-tor.svg?branch=master)](http://travis-ci.org/GaloisInc/haskell-tor)
+
     This version of haskell-tor is (C) 2015 Galois, Inc., and distributed under
     a standard, three-clause BSD license. Please see the file LICENSE,
     distributed with this software, for specific terms and conditions.


### PR DESCRIPTION
It seems the build is currently failing on travis. It would be nice to be able to see that on the README.
