### PR TITLE
Make haskell-tor buildable with ghc 7.6.4.

### DIFF
--- a/haskell-tor.cabal
+++ b/haskell-tor.cabal
@@ -38,12 +38,12 @@ library
   hs-source-dirs:     src
 
   build-depends:
-                      array                      >= 0.5   && < 0.7,
+                      array                      >= 0.4   && < 0.7,
                       asn1-encoding              >= 0.9   && < 0.11,
                       asn1-types                 >= 0.3   && < 0.5,
                       async                      >= 2.0.2 && < 2.2,
                       attoparsec                 >= 0.13  && < 0.15,
-                      base                       >= 4.7   && < 5.0,
+                      base                       >= 4.6   && < 5.0,
                       base64-bytestring          >= 1.0   && < 1.2,
                       binary                     >= 0.7.1 && < 0.9,
                       bytestring                 >= 0.10  && < 0.11,
@@ -109,7 +109,7 @@ executable haskell-tor
   build-depends:
                       asn1-encoding              >= 0.8   && < 0.10,
                       asn1-types                 >= 0.2   && < 0.4,
-                      base                       >= 4.7   && < 5.0,
+                      base                       >= 4.6   && < 5.0,
                       base64-bytestring          >= 1.0   && < 1.2,
                       bytestring                 >= 0.10  && < 0.11,
                       cryptonite                 >= 0.6   && < 0.10,
@@ -145,7 +145,7 @@ test-suite test-tor
   ghc-options:        -fno-warn-orphans
   build-depends:
                       asn1-types                 >= 0.2   && < 0.4,
-                      base                       >= 4.7   && < 5.0,
+                      base                       >= 4.6   && < 5.0,
                       binary                     >= 0.7   && < 0.9,
                       bytestring                 >= 0.10  && < 0.11,
                       cryptonite                 >= 0.6   && < 0.10,


### PR DESCRIPTION
I don't know the correct solution to the tryReadMVar replacement, but
this compiles and the test does not deadlock.
